### PR TITLE
Formulierung bei "Vollständigkeit"

### DIFF
--- a/output-monad/src/Control/Monad/Output.hs
+++ b/output-monad/src/Control/Monad/Output.hs
@@ -143,12 +143,12 @@ multipleChoice what msolutionString solution choices =
       (toMapping (M.keys solution) cs)
     isCorrect = null [c | c <- cs, c `notElem` valid]
     correctnessCheck = yesNo isCorrect $ multiLang [
-      (English, "Given " ++ localise English what ++ " are correct?"),
+      (English, "The given " ++ localise English what ++ " are correct?"),
       (German, "Die angegebenen " ++ localise German what ++ " sind korrekt?")
       ]
     exhaustivenessCheck =  when isCorrect $ yesNo (cs ==  valid) $ multiLang [
-      (English, "Given " ++ localise English what ++ " are exhaustive?"),
-      (German, "Die angegebenen " ++ localise German what ++ " sind vollständig?")
+      (English, "The given " ++ localise English what ++ " are exhaustive?"),
+      (German, "Die angegebenen " ++ localise German what ++ " sind vollzählig?")
       ]
     valid = M.keys $ M.filter id solution
 

--- a/output-monad/src/Control/Monad/Output.hs
+++ b/output-monad/src/Control/Monad/Output.hs
@@ -143,8 +143,8 @@ multipleChoice what msolutionString solution choices =
       (toMapping (M.keys solution) cs)
     isCorrect = null [c | c <- cs, c `notElem` valid]
     correctnessCheck = yesNo isCorrect $ multiLang [
-      (English, "The given " ++ localise English what ++ " are correct?"),
-      (German, "Die angegebenen " ++ localise German what ++ " sind korrekt?")
+      (English, "All given " ++ localise English what ++ " are correct?"),
+      (German, "Alle angegebenen " ++ localise German what ++ " sind korrekt?")
       ]
     exhaustivenessCheck =  when isCorrect $ yesNo (cs ==  valid) $ multiLang [
       (English, "The given " ++ localise English what ++ " are exhaustive?"),


### PR DESCRIPTION
Ich fand diese Feedback-Anzeige problematisch:
> Die angegebenen Terme sind vollständig.

Da liegt die Interpretation in der Luft, es gäbe unvollständige Terme. Es ging aber eigentlich um die Menge der Terme, die zu klein sein könnte (nicht zu kleine Terme).

Mit dem neuen Vorschlag stünde dort:
> Die angegebenen Terme sind vollzählig.

Eine auch denkbare Alternative wäre:
> Die Angabe der Terme ist vollständig.

(Zu dieser wäre es dann vielleicht sinnvoll, auch im Englischen eine Umformulierung zu machen.)

Ich überblicke nicht, ob es vielleicht irgendeine bisherige Verwendung der Funktion gibt (mit was anderem als "Terme"), bei der die Umformulierungen zu einer Verschlechterung des Feedbacks führen (etwa weil in jenem Kontext "vollzählig" ein bereits belegter Begriff ist). Vielleicht lassen wir es einfach drauf ankommen. :smile: